### PR TITLE
feat: coin order

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ Coin/token info stored in `\general\${token_name}` folders. Specific blockchain 
   // Should an app itself create the coin or only use the info for the blockchain
   "createCoin": true,
 
+  "defaultVisibility": true, // Optional. To show a coin by default, or hide it
+  "defaultOrder": 0, // Optional. Default order in a wallet list. Coins with the same order are sorted alphabetically. Coins without an order are shown last, alphabetically
+
   "consensus": "dPoS", // Optional. Blockchain consensus type
   "blockTimeFixed": 5000, // Optional. Fixed block time in ms
   "blockTimeAvg": 600000, // Optional. Average block time in ms

--- a/assets/blockchains/ethereum/usds/info.json
+++ b/assets/blockchains/ethereum/usds/info.json
@@ -2,6 +2,8 @@
   "name": "Stably USD",
   "symbol": "USDS",
   "status": "active",
+  "defaultVisibility": true,
+  "defaultOrder": 100,
   "contractId": "0xa4bdb11dc0a2bec88d24a3aa1e6bb17201112ebe",
   "decimals": 6
 }

--- a/assets/general/adamant/info.json
+++ b/assets/general/adamant/info.json
@@ -15,6 +15,8 @@
   "qqPrefix": "adm",
   "status": "active",
   "createCoin": true,
+  "defaultVisibility": true,
+  "defaultOrder": 0,
   "consensus": "dPoS",
   "blockTimeFixed": 5000,
   "nodes": [

--- a/assets/general/bitcoin/info.json
+++ b/assets/general/bitcoin/info.json
@@ -16,6 +16,8 @@
   "qqPrefix": "bitcoin",
   "status": "active",
   "createCoin": true,
+  "defaultVisibility": true,
+  "defaultOrder": 10,
   "consensus": "PoW",
   "blockTimeAvg": 600000,
   "txFetchInfo": {

--- a/assets/general/dash/info.json
+++ b/assets/general/dash/info.json
@@ -17,6 +17,8 @@
   "qqPrefix": "dash",
   "status": "active",
   "createCoin": true,
+  "defaultVisibility": true,
+  "defaultOrder": 50,
   "consensus": "PoW",
   "blockTimeAvg": 160000,
   "txFetchInfo" : {

--- a/assets/general/doge/info.json
+++ b/assets/general/doge/info.json
@@ -15,6 +15,8 @@
   "qqPrefix": "doge",
   "status": "active",
   "createCoin": true,
+  "defaultVisibility": true,
+  "defaultOrder": 40,
   "consensus": "PoW",
   "blockTimeAvg": 60000,
   "txFetchInfo": {

--- a/assets/general/ethereum/info.json
+++ b/assets/general/ethereum/info.json
@@ -14,6 +14,8 @@
   "status": "active",
   "qqPrefix": "ethereum",
   "createCoin": true,
+  "defaultVisibility": true,
+  "defaultOrder": 20,
   "consensus": "PoS",
   "blockTimeFixed": 12000,
   "txFetchInfo": {

--- a/assets/general/lisk/info.json
+++ b/assets/general/lisk/info.json
@@ -15,6 +15,8 @@
   "qqPrefix": "lisk",
   "status": "active",
   "createCoin": true,
+  "defaultVisibility": true,
+  "defaultOrder": 30,
   "consensus": "dPoS",
   "blockTimeFixed": 10000,
   "txFetchInfo": {


### PR DESCRIPTION
- Specific blockchain info in `\blockchains\${blockchain_name}` overrides `defaultVisibility` and `defaultOrder`
- Default for `defaultVisibility` is false