### PR TITLE
fix(Bitcoin, regexAddress): JS regexp doesn't support `(?i)` syntax

### DIFF
--- a/assets/general/bitcoin/info.json
+++ b/assets/general/bitcoin/info.json
@@ -5,7 +5,7 @@
   "explorer": "https://explorer.btc.com",
   "explorerTx": "https://explorer.btc.com/btc/transaction/${ID}",
   "explorerAddress": "https://explorer.btc.com/btc/address/${ID}",
-  "regexAddress": "^bc1(?i)[a-z0-9]{39,59}$|^[13][1-9A-HJ-NP-Za-km-z]{25,34}$",
+  "regexAddress": "^bc1[a-zA-Z0-9]{39,59}$|^[13][1-9A-HJ-NP-Za-km-z]{25,34}$",
   "symbol": "BTC",
   "type": "coin",
   "decimals": 8,


### PR DESCRIPTION
https://trello.com/c/QqGgDait/391-invalid-regular-expression-btc-address-when-starting-new-chat