### PR TITLE
fix(Lisk): update min fee required by Lisk v4

### DIFF
--- a/assets/general/lisk/info.json
+++ b/assets/general/lisk/info.json
@@ -11,7 +11,7 @@
   "decimals": 8,
   "minBalance": 0.05,
   "cryptoTransferDecimals": 8,
-  "defaultFee": 0.00142,
+  "defaultFee": 0.00164,
   "qqPrefix": "lisk",
   "status": "active",
   "createCoin": true,


### PR DESCRIPTION
Sending a transaction with a fee lower than 164000 will throw an error. Checked on Lisk v4 Mainnet.

From node logs: `Insufficient transaction fee. Minimum required fee is 164000`