### PR TITLE
Rollback Lisk nodes/services

### DIFF
--- a/assets/general/lisk/info.json
+++ b/assets/general/lisk/info.json
@@ -29,12 +29,28 @@
   "txConsistencyMaxTime": 60000,
   "nodes": [
     {
+      "url": "https://lisknode3.adamant.im",
+      "alt_ip": "http://157.90.229.236:8002"
+    },
+    {
+      "url": "https://lisknode4.adamant.im",
+      "alt_ip": "http://78.47.205.206:8002"
+    },
+    {
       "url": "https://lisknode5.adamant.im",
       "alt_ip": "http://38.242.243.29:44099"
     }
   ],
   "services": {
     "lskService": [
+      {
+        "url": "https://liskservice3.adamant.im",
+        "alt_ip": "http://157.90.229.236:9904"
+      },
+      {
+        "url": "https://liskservice4.adamant.im",
+        "alt_ip": "http://78.47.205.206:9904"
+      },
       {
         "url": "https://liskservice5.adamant.im",
         "alt_ip": "http://38.242.243.29:44098"
@@ -58,11 +74,23 @@
   "tor": {
     "nodes": [
       {
+        "url": "http://nl2c4vcsdrd6je3ebt4236yst55mbso72ojmksrmlyoikapgnu647tid.onion"
+      },
+      {
+        "url": "http://qpjxvkathebm7oso3dk5hb4cggbeecqvcpcthuxlpovtn66plr6f4wyd.onion"
+      },
+      {
         "url": "http://4bsg7dijnpkiu6wylaad5fiom4iep73oz3o2rojkwnuteaawd2w3o2ad.onion"
       }
     ],
     "services": {
       "lskService": [
+        {
+          "url": "http://xqrymra5go2nb3cslb3c3iv4weeuicybcxpjee4ay2indk2hgo7rw4qd.onion"
+        },
+        {
+          "url": "http://s2q6phc22icy73zjccjq66555gwtvyuyrodmadwhjdhmvyehb3qrcsid.onion"
+        },
         {
           "url": "http://cf6vf6xylvhza3t3ewffa7cmr2bqgaus5jwghiktjleids5ovdhoazad.onion"
         }

--- a/assets/general/lisk/info.json
+++ b/assets/general/lisk/info.json
@@ -30,11 +30,11 @@
   "nodes": [
     {
       "url": "https://lisknode3.adamant.im",
-      "alt_ip": "http://157.90.229.236:8002"
+      "alt_ip": "http://157.90.229.236:44099"
     },
     {
       "url": "https://lisknode4.adamant.im",
-      "alt_ip": "http://78.47.205.206:8002"
+      "alt_ip": "http://78.47.205.206:44099"
     },
     {
       "url": "https://lisknode5.adamant.im",
@@ -45,11 +45,11 @@
     "lskService": [
       {
         "url": "https://liskservice3.adamant.im",
-        "alt_ip": "http://157.90.229.236:9904"
+        "alt_ip": "http://157.90.229.236:44098"
       },
       {
         "url": "https://liskservice4.adamant.im",
-        "alt_ip": "http://78.47.205.206:9904"
+        "alt_ip": "http://78.47.205.206:44098"
       },
       {
         "url": "https://liskservice5.adamant.im",


### PR DESCRIPTION
Rollback the following nodes/services into config:

- https://lisknode3.adamant.im
- https://lisknode4.adamant.im
- https://liskservice3.adamant.im
- https://liskservice4.adamant.im

> [!NOTE]  
> Merge it only after upgrading nodes and services up to the latest version.