### PR TITLE
Introduce `increasedGasPricePercent`

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,9 +144,9 @@ The total cost of a transaction is the product of the gas limit and gas price:
 Tx \, fee = gas \, limit \times gas \, price
 ```
 
-ADAMANT apps estimate gas limit and gas price using [web3](https://github.com/web3/web3.js) library. To make sure the Ethereum blockchain will include the tx, these estimates must be multiplied by `reliabilityGasLimitPercent` and `reliabilityGasPricePercent`.
+ADAMANT apps estimate gas limit and gas price using [web3](https://github.com/web3/web3.js) library. To ensure the Ethereum blockchain will accept the tx, apps multiply these estimates by `reliabilityGasLimitPercent` and `reliabilityGasPricePercent`. Additionally, an pp may offer the "Increase fee" option to use the `increasedGasPricePercent` koef.
 
-If it’s not possible to get estimates, apps will use `defaultGasLimit` and `defaultGasPriceGwei`. When gas price is higher than `warningGasPriceGwei`, apps will show a note/warning.
+If it’s not possible to get estimates, apps will use `defaultGasLimit` and `defaultGasPriceGwei`. When the gas price exceeds `warningGasPriceGwei`, apps show a note/warning.
 
 These parameters are set inside `general\ethereum\info.json` and may be overridden by `blockchains\ethereum\info.json` and specific tokens.
 

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ The total cost of a transaction is the product of the gas limit and gas price:
 Tx \, fee = gas \, limit \times gas \, price
 ```
 
-ADAMANT apps estimate gas limit and gas price using [web3](https://github.com/web3/web3.js) library. To ensure the Ethereum blockchain will accept the tx, apps multiply these estimates by `reliabilityGasLimitPercent` and `reliabilityGasPricePercent`. Additionally, an pp may offer the "Increase fee" option to use the `increasedGasPricePercent` koef.
+ADAMANT apps estimate gas limit and gas price using [web3](https://github.com/web3/web3.js) library. To ensure the Ethereum blockchain will accept the tx, apps multiply these estimates by `reliabilityGasLimitPercent` and `reliabilityGasPricePercent`. Additionally, an app may offer the "Increase fee" option to use the `increasedGasPricePercent` koef.
 
 If it’s not possible to get estimates, apps will use `defaultGasLimit` and `defaultGasPriceGwei`. When the gas price exceeds `warningGasPriceGwei`, apps show a note/warning.
 

--- a/assets/general/ethereum/info.json
+++ b/assets/general/ethereum/info.json
@@ -28,9 +28,10 @@
   "txConsistencyMaxTime": 1200000,
   "reliabilityGasPricePercent": 10,
   "reliabilityGasLimitPercent": 10,
-  "defaultGasPriceGwei": 30,
+  "increasedGasPricePercent": 30,
+  "defaultGasPriceGwei": 10,
   "defaultGasLimit": 22000,
-  "warningGasPriceGwei": 70,
+  "warningGasPriceGwei": 25,
   "nodes": {
     "list": [
       {


### PR DESCRIPTION
An app may offer the "Increase fee" option to use the `increasedGasPricePercent` koef:

* Instead of using 1.5x constant, use `increasedGasPricePercent`
* Ensure that client apps **keep Gas limit as is**, and **increase Gas price** by `increasedGasPricePercent`
