### PR TITLE
feat: increase `threshold` to keep IPFS nodes synced

### DIFF
--- a/assets/general/adamant/info.json
+++ b/assets/general/adamant/info.json
@@ -134,7 +134,8 @@
       "healthCheck": {
         "normalUpdateInterval": 300000,
         "crucialUpdateInterval": 30000,
-        "onScreenUpdateInterval": 10000
+        "onScreenUpdateInterval": 10000,
+        "threshold": 6000000
       }
     }
   },
@@ -230,7 +231,8 @@
         "healthCheck": {
           "normalUpdateInterval": 300000,
           "crucialUpdateInterval": 30000,
-          "onScreenUpdateInterval": 10000
+          "onScreenUpdateInterval": 10000,
+          "threshold": 6000000
         }
       }
     }


### PR DESCRIPTION
Since IPFS nodes do not have a height (unlike blockchain nodes), we use the timestamp instead. Because the difference can be significant, causing the nodes to remain in a "Syncing" state, I increased the default value from 10,000 ms to 6,000,000 ms (100 minutes).

![image](https://github.com/user-attachments/assets/e8d1dc90-d877-46e8-a493-b415efa0b5d2)
