### PR TITLE
feat: add DOGE indexer

### DIFF
--- a/assets/general/doge/info.json
+++ b/assets/general/doge/info.json
@@ -51,6 +51,36 @@
       "threshold": 3
     }
   },
+  "services": {
+    "dogeIndexer": {
+      "displayName": "doge-indexer",
+      "description": {
+        "software": "Esplora/Electrs",
+        "github": "https://github.com/blockstream/electrs",
+        "docs": "https://github.com/blockstream/esplora/blob/master/API.md"
+      },
+      "list": [
+        {
+          "url": "https://dogenode1.adamant.im/api",
+          "alt_ip": "http://5.9.99.62:44099"
+        },
+        {
+          "url": "https://dogenode2.adamant.im/api",
+          "alt_ip": "http://176.9.32.126:44098"
+        },
+        {
+          "url": "https://dogenode3.adm.im/api",
+          "alt_ip": "http://95.216.45.88:44098"
+        }
+      ],
+      "healthCheck": {
+        "normalUpdateInterval": 390000,
+        "crucialUpdateInterval": 30000,
+        "onScreenUpdateInterval": 10000,
+        "threshold": 3
+      }
+    }
+  },
   "links": [
     {
       "name": "github",
@@ -88,6 +118,33 @@
         "crucialUpdateInterval": 30000,
         "onScreenUpdateInterval": 10000,
         "threshold": 3
+      }
+    },
+    "services": {
+      "dogeIndexer": {
+        "displayName": "doge-indexer",
+        "description": {
+          "software": "Esplora/Electrs",
+          "github": "https://github.com/blockstream/electrs",
+          "docs": "https://github.com/blockstream/esplora/blob/master/API.md"
+        },
+        "list": [
+          {
+            "url": "http://mtg4mq43p67cbj6qwcqgppjv7uzm7ximjlzapsbnbh5ls6zqkjsq26ad.onion/api"
+          },
+          {
+            "url": "http://bfu3iiofsagyhi22zijfilbkzlzbalpylhhfcluqmezx2avdwcxut7yd.onion/api"
+          },
+          {
+            "url": "http://tdl25bmpwystxnm6hxzqdrkaxxdicknbigs5umob2nlgcbbqgidd64qd.onion/api"
+          }
+        ],
+        "healthCheck": {
+          "normalUpdateInterval": 390000,
+          "crucialUpdateInterval": 30000,
+          "onScreenUpdateInterval": 10000,
+          "threshold": 3
+        }
       }
     }
   }

--- a/assets/general/doge/info.json
+++ b/assets/general/doge/info.json
@@ -62,15 +62,15 @@
       "list": [
         {
           "url": "https://dogenode1.adamant.im/api",
-          "alt_ip": "http://5.9.99.62:44099"
+          "alt_ip": "http://5.9.99.62:44099/api"
         },
         {
           "url": "https://dogenode2.adamant.im/api",
-          "alt_ip": "http://176.9.32.126:44098"
+          "alt_ip": "http://176.9.32.126:44098/api"
         },
         {
           "url": "https://dogenode3.adm.im/api",
-          "alt_ip": "http://95.216.45.88:44098"
+          "alt_ip": "http://95.216.45.88:44098/api"
         }
       ],
       "healthCheck": {


### PR DESCRIPTION
We have two different apps running on same domain. The Doge Indexer was missing in the configuration.

## Doge Indexer

Path: `/api/*`
Methods: `GET`, `POST`

Example:

- GET `/api/status`
- GET `/api/tx/${txid}`
- POST `/api/tx/send`

## Doge Node

Path: `/`
Methods: `POST`

Example:

```
POST /
{
  method: 'getblockchaininfo',
  params: []
}
```

Task: https://trello.com/c/ix6BKOJ6/496-adamant-wallets-add-doge-indexer

