### PR TITLE
Chore: Change default visibility for ERC20 and few other fixes

### DIFF
--- a/assets/blockchains/ethereum/bnb/info.json
+++ b/assets/blockchains/ethereum/bnb/info.json
@@ -2,6 +2,8 @@
   "name": "Binance Coin",
   "symbol": "BNB",
   "status": "active",
+  "defaultVisibility": false,
+  "defaultOrdinalLevel": 1000,
   "contractId": "0xB8c77482e45F1F44dE1745F52C74426C631bDD52",
   "decimals": 18
 }

--- a/assets/blockchains/ethereum/busd/info.json
+++ b/assets/blockchains/ethereum/busd/info.json
@@ -2,6 +2,8 @@
   "name": "Binance USD",
   "symbol": "BUSD",
   "status": "active",
+  "defaultVisibility": false,
+  "defaultOrdinalLevel": 1000,
   "contractId": "0x4fabb145d64652a948d72533023f6e7a623c7c53",
   "decimals": 18
 }

--- a/assets/blockchains/ethereum/bzz/info.json
+++ b/assets/blockchains/ethereum/bzz/info.json
@@ -5,5 +5,6 @@
   "defaultVisibility": false,
   "defaultOrdinalLevel": 95,
   "contractId": "0x19062190B1925b5b6689D7073fDfC8c2976EF8Cb",
-  "decimals": 16
+  "decimals": 16,
+  "cryptoTransferDecimals": 6
 }

--- a/assets/blockchains/ethereum/ens/info.json
+++ b/assets/blockchains/ethereum/ens/info.json
@@ -2,6 +2,8 @@
   "name": "Ethereum Name Service",
   "symbol": "ENS",
   "status": "active",
+  "defaultVisibility": false,
+  "defaultOrdinalLevel": 1000,
   "contractId": "0xC18360217D8F7Ab5e7c516566761Ea12Ce7F9D72",
   "decimals": 18
 }

--- a/assets/blockchains/ethereum/floki/info.json
+++ b/assets/blockchains/ethereum/floki/info.json
@@ -3,7 +3,8 @@
   "symbol": "FLOKI",
   "status": "active",
   "defaultVisibility": false,
-  "defaultOrdinalLevel": 100,
+  "defaultOrdinalLevel": 1000,
   "contractId": "0xcf0c122c6b73ff809c693db761e7baebe62b6a2e",
-  "decimals": 9
+  "decimals": 9,
+  "cryptoTransferDecimals": 6
 }

--- a/assets/blockchains/ethereum/flux/info.json
+++ b/assets/blockchains/ethereum/flux/info.json
@@ -5,5 +5,6 @@
   "defaultVisibility": false,
   "defaultOrdinalLevel": 90,
   "contractId": "0x720CD16b011b987Da3518fbf38c3071d4F0D1495",
-  "decimals": 8
+  "decimals": 8,
+  "cryptoTransferDecimals": 6
 }

--- a/assets/blockchains/ethereum/gt/info.json
+++ b/assets/blockchains/ethereum/gt/info.json
@@ -3,7 +3,7 @@
   "symbol": "GT",
   "status": "active",
   "defaultVisibility": false,
-  "defaultOrdinalLevel": 115,
+  "defaultOrdinalLevel": 1000,
   "contractId": "0xe66747a101bff2dba3697199dcce5b743b454759",
   "decimals": 18
 }

--- a/assets/blockchains/ethereum/hot/info.json
+++ b/assets/blockchains/ethereum/hot/info.json
@@ -2,6 +2,8 @@
   "name": "Holo",
   "symbol": "HOT",
   "status": "active",
+  "defaultVisibility": false,
+  "defaultOrdinalLevel": 1000,
   "contractId": "0x6c6ee5e31d828de241282b9606c8e98ea48526e2",
   "decimals": 18
 }

--- a/assets/blockchains/ethereum/info.json
+++ b/assets/blockchains/ethereum/info.json
@@ -3,5 +3,9 @@
   "type": "ERC20",
   "mainCoin": "ethereum",
   "fees": "ethereum",
+  "reliabilityGasPricePercent": 15,
+  "reliabilityGasLimitPercent": 10,
+  "increasedGasPricePercent": 30,
+  "defaultGasPriceGwei": 10,
   "defaultGasLimit": 58000
 }

--- a/assets/blockchains/ethereum/inj/info.json
+++ b/assets/blockchains/ethereum/inj/info.json
@@ -2,6 +2,8 @@
   "name": "Injective",
   "symbol": "INJ",
   "status": "active",
+  "defaultVisibility": false,
+  "defaultOrdinalLevel": 200,
   "contractId": "0xe28b3b32b6c345a34ff64674606124dd5aceca30",
   "decimals": 18
 }

--- a/assets/blockchains/ethereum/link/info.json
+++ b/assets/blockchains/ethereum/link/info.json
@@ -2,6 +2,8 @@
   "name": "Chainlink",
   "symbol": "LINK",
   "status": "active",
+  "defaultVisibility": false,
+  "defaultOrdinalLevel": 200,
   "contractId": "0x514910771af9ca656af840dff83e8264ecf986ca",
   "decimals": 18
 }

--- a/assets/blockchains/ethereum/mana/info.json
+++ b/assets/blockchains/ethereum/mana/info.json
@@ -2,6 +2,8 @@
   "name": "Decentraland",
   "symbol": "MANA",
   "status": "active",
+  "defaultVisibility": false,
+  "defaultOrdinalLevel": 1000,
   "contractId": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
   "decimals": 18
 }

--- a/assets/blockchains/ethereum/matic/info.json
+++ b/assets/blockchains/ethereum/matic/info.json
@@ -2,6 +2,8 @@
   "name": "Polygon",
   "symbol": "MATIC",
   "status": "active",
+  "defaultVisibility": false,
+  "defaultOrdinalLevel": 1000,
   "contractId": "0x7d1afa7b718fb893db30a3abc0cfc608aacfebb0",
   "decimals": 18
 }

--- a/assets/blockchains/ethereum/paxg/info.json
+++ b/assets/blockchains/ethereum/paxg/info.json
@@ -2,6 +2,8 @@
   "name": "PAX Gold",
   "symbol": "PAXG",
   "status": "active",
+  "defaultVisibility": false,
+  "defaultOrdinalLevel": 100,
   "contractId": "0x45804880de22913dafe09f4980848ece6ecbaf78",
   "decimals": 18
 }

--- a/assets/blockchains/ethereum/qnt/info.json
+++ b/assets/blockchains/ethereum/qnt/info.json
@@ -2,6 +2,8 @@
   "name": "Quant",
   "symbol": "QNT",
   "status": "active",
+  "defaultVisibility": false,
+  "defaultOrdinalLevel": 1000,
   "contractId": "0x4a220E6096B25EADb88358cb44068A3248254675",
   "decimals": 18
 }

--- a/assets/blockchains/ethereum/ren/info.json
+++ b/assets/blockchains/ethereum/ren/info.json
@@ -2,6 +2,8 @@
   "name": "Ren",
   "symbol": "REN",
   "status": "active",
+  "defaultVisibility": false,
+  "defaultOrdinalLevel": 1000,
   "contractId": "0x408e41876cccdc0f92210600ef50372656052a38",
   "decimals": 18
 }

--- a/assets/blockchains/ethereum/snt/info.json
+++ b/assets/blockchains/ethereum/snt/info.json
@@ -2,6 +2,8 @@
   "name": "Status",
   "symbol": "SNT",
   "status": "active",
+  "defaultVisibility": false,
+  "defaultOrdinalLevel": 1000,
   "contractId": "0x744d70fdbe2ba4cf95131626614a1763df805b9e",
   "decimals": 18
 }

--- a/assets/blockchains/ethereum/snx/info.json
+++ b/assets/blockchains/ethereum/snx/info.json
@@ -2,6 +2,8 @@
   "name": "Synthetix Network",
   "symbol": "SNX",
   "status": "active",
+  "defaultVisibility": false,
+  "defaultOrdinalLevel": 200,
   "contractId": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
   "decimals": 18
 }

--- a/assets/blockchains/ethereum/storj/info.json
+++ b/assets/blockchains/ethereum/storj/info.json
@@ -5,5 +5,6 @@
   "defaultVisibility": false,
   "defaultOrdinalLevel": 105,
   "contractId": "0xb64ef51c888972c908cfacf59b47c1afbc0ab8ac",
-  "decimals": 8
+  "decimals": 8,
+  "cryptoTransferDecimals": 6
 }

--- a/assets/blockchains/ethereum/tusd/info.json
+++ b/assets/blockchains/ethereum/tusd/info.json
@@ -2,6 +2,8 @@
   "name": "TrueUSD",
   "symbol": "TUSD",
   "status": "active",
+  "defaultVisibility": false,
+  "defaultOrdinalLevel": 100,
   "contractId": "0x0000000000085d4780b73119b644ae5ecd22b376",
   "decimals": 18
 }

--- a/assets/blockchains/ethereum/uni/info.json
+++ b/assets/blockchains/ethereum/uni/info.json
@@ -2,6 +2,8 @@
   "name": "Uniswap",
   "symbol": "UNI",
   "status": "active",
+  "defaultVisibility": false,
+  "defaultOrdinalLevel": 1000,
   "contractId": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
   "decimals": 18
 }

--- a/assets/blockchains/ethereum/usdc/info.json
+++ b/assets/blockchains/ethereum/usdc/info.json
@@ -5,5 +5,6 @@
   "defaultVisibility": true,
   "defaultOrdinalLevel": 40,
   "contractId": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
-  "decimals": 6
+  "decimals": 6,
+  "cryptoTransferDecimals": 6
 }

--- a/assets/blockchains/ethereum/usdp/info.json
+++ b/assets/blockchains/ethereum/usdp/info.json
@@ -1,7 +1,9 @@
 {
-  "name": "PAX Dollar",
+  "name": "Pax Dollar",
   "symbol": "USDP",
   "status": "active",
+  "defaultVisibility": false,
+  "defaultOrdinalLevel": 100,
   "contractId": "0x8e870d67f660d95d5be530380d0ec0bd388289e1",
   "decimals": 18
 }

--- a/assets/blockchains/ethereum/usds/info.json
+++ b/assets/blockchains/ethereum/usds/info.json
@@ -2,6 +2,9 @@
   "name": "Stably USD",
   "symbol": "USDS",
   "status": "active",
+  "defaultVisibility": false,
+  "defaultOrdinalLevel": 1000,
   "contractId": "0xa4bdb11dc0a2bec88d24a3aa1e6bb17201112ebe",
-  "decimals": 6
+  "decimals": 6,
+  "cryptoTransferDecimals": 6
 }

--- a/assets/blockchains/ethereum/usdt/info.json
+++ b/assets/blockchains/ethereum/usdt/info.json
@@ -5,5 +5,6 @@
   "defaultVisibility": true,
   "defaultOrdinalLevel": 30,
   "contractId": "0xdac17f958d2ee523a2206206994597c13d831ec7",
-  "decimals": 6
+  "decimals": 6,
+  "cryptoTransferDecimals": 6
 }

--- a/assets/blockchains/ethereum/woo/info.json
+++ b/assets/blockchains/ethereum/woo/info.json
@@ -2,6 +2,8 @@
   "name": "WOO Network",
   "symbol": "WOO",
   "status": "active",
+  "defaultVisibility": false,
+  "defaultOrdinalLevel": 1000,
   "contractId": "0x4691937a7508860f876c9c0a2a617e7d9e945d4b",
   "decimals": 18
 }

--- a/assets/general/ethereum/info.json
+++ b/assets/general/ethereum/info.json
@@ -27,9 +27,9 @@
   },
   "txConsistencyMaxTime": 1200000,
   "reliabilityGasPricePercent": 10,
-  "reliabilityGasLimitPercent": 10,
-  "increasedGasPricePercent": 30,
-  "defaultGasPriceGwei": 10,
+  "reliabilityGasLimitPercent": 5,
+  "increasedGasPricePercent": 25,
+  "defaultGasPriceGwei": 5,
   "defaultGasLimit": 22000,
   "warningGasPriceGwei": 25,
   "nodes": {

--- a/assets/general/usdp/info.json
+++ b/assets/general/usdp/info.json
@@ -1,5 +1,5 @@
 {
-  "name": "PAX Dollar",
+  "name": "Pax Dollar",
   "website": "https://www.paxos.com/usdp",
   "description": "PAX Dollar is a regulated stablecoin collateralized 1:1 by United States Dollars held in US bank",
   "symbol": "USDP",


### PR DESCRIPTION
- ERC20 token `defaultVisibility`
- ERC20 token `defaultOrdinalLevel`
- ERC20 explicit `cryptoTransferDecimals` where `decimals` < 18
- Default "ethereum" blockchain gas params
- Default Ethereum coin gas params
- PAX Dollar ⟶ Pax Dollar name