### PR TITLE
Don't show KLY by default

### DIFF
--- a/assets/general/klayr/info.json
+++ b/assets/general/klayr/info.json
@@ -15,7 +15,7 @@
   "qqPrefix": "klayr",
   "status": "active",
   "createCoin": true,
-  "defaultVisibility": true,
+  "defaultVisibility": false,
   "defaultOrdinalLevel": 50,
   "consensus": "dPoS",
   "blockTimeFixed": 10000,


### PR DESCRIPTION
Klayr is migrating to a new infrastructure, and their nodes will be unavailable/unstable for some time.
