### PR TITLE
Chore: refresh deprecated node and IPFS fallbacks

### DIFF
--- a/assets/general/adamant/info.json
+++ b/assets/general/adamant/info.json
@@ -102,7 +102,7 @@
       "list": [
         {
           "url": "https://info.adamant.im",
-          "alt_ip": "http://5.161.98.136:33088"
+          "alt_ip": "http://46.4.37.157:33088"
         },
         {
           "url": "https://info2.adm.im",
@@ -211,7 +211,7 @@
         "list": [
           {
             "url": "https://info.adamant.im",
-            "alt_ip": "http://5.161.98.136:33088"
+            "alt_ip": "http://46.4.37.157:33088"
           },
           {
             "url": "https://info2.adm.im",

--- a/assets/general/adamant/info.json
+++ b/assets/general/adamant/info.json
@@ -48,10 +48,6 @@
       { "url": "http://184.94.215.92:45555" },
       { "url": "https://node2.blockchain2fa.io" },
       {
-        "url": "https://phecda.adm.im",
-        "alt_ip": "http://46.250.234.248:36666"
-      },
-      {
         "url": "https://tegmine.adm.im"
       },
       {

--- a/assets/general/adamant/info.json
+++ b/assets/general/adamant/info.json
@@ -138,7 +138,7 @@
       "list": [
         {
           "url": "https://ipfs4.adm.im",
-          "alt_ip": "http://95.216.45.88:44099"
+          "alt_ip": "http://209.188.7.216:44099"
         },
         {
           "url": "https://ipfs6.adamant.business",

--- a/assets/general/adamant/info.json
+++ b/assets/general/adamant/info.json
@@ -331,9 +331,6 @@
             "url": "http://z455rax4mwcseyc7efog7czrbwdvphwocatl5sjcc6htcoj2k2vz7dad.onion"
           },
           {
-            "url": "http://cds45bjd7ynxkffxpzfifnm55r6vmhgocvpvonjmry3mrskuhda6z7qd.onion"
-          },
-          {
             "url": "http://3ytwoe62bqw264v4rkaqpn5iovdg3oxly5tx2uc5qijkrdqixm6tmdyd.onion"
           }
         ],

--- a/assets/general/doge/info.json
+++ b/assets/general/doge/info.json
@@ -39,7 +39,7 @@
       },
       {
         "url": "https://dogenode3.adm.im",
-        "alt_ip": "http://95.216.45.88:44098"
+        "alt_ip": "http://195.201.242.108:44098"
       },
       {
         "url": "https://dogenode3.bbry.org",
@@ -68,7 +68,7 @@
         },
         {
           "url": "https://dogenode3.adm.im/api",
-          "alt_ip": "http://95.216.45.88:44098/api"
+          "alt_ip": "http://195.201.242.108:44098/api"
         },
         {
           "url": "https://dogenode2.bbry.org/api",


### PR DESCRIPTION
## Description

This PR refreshes deprecated node and IPFS fallbacks in shared wallet metadata for ADM and DOGE.

- Removes a deprecated ADM node entry and a deprecated Tor IPFS onion endpoint
- Updates `alt_ip` fallbacks for `info.adamant.im`, `ipfs4.adm.im`, and `dogenode3.adm.im`
- Keeps the metadata shape unchanged, so no README or OpenAPI updates are required

## Related issue

Closes #133

## External links (optional)

None.

## Screenshots or videos (optional)

N/A

## Breaking changes

No.

## How to test

1. Run `pnpm exec prettier --check assets/general/adamant/info.json assets/general/doge/info.json`
2. Review `git diff origin/dev...HEAD` and verify that only deprecated node entries and `alt_ip` values were updated.
3. Optionally confirm ADM info/IPFS and DOGE service resolution in downstream wallet consumers.

## Notes for reviewers

Please focus on the shared ADM metadata changes, especially the removed deprecated endpoints and the replacement `alt_ip` values.

## Checklist

- [x] Code is formatted
- [x] Tests added/updated (if needed)
- [x] Documentation updated (if needed)
- [ ] Changes tested in all relevant environments