### PR TITLE
Infrastructure: Replace retired wallet node endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 - Updated Dogecoin node and indexer IP fallbacks for the migrated `dogenode2` host
 - Added deterministic node and service endpoint validation to the repository validation suite
 - Updated Prettier and lint-staged to their latest compatible releases
+- Updated the pinned pnpm version from 10.11.0 to 11.18.0
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Changed
+
+- Updated Bitcoin node and indexer IP fallbacks for the new `btcnode1` host
+- Updated Dogecoin node and indexer IP fallbacks for the migrated `dogenode2` host
+- Added deterministic node and service endpoint validation to the repository validation suite
+- Updated Prettier and lint-staged to their latest compatible releases
+
+### Removed
+
+- Removed retired `btcnode1.bbry.org`, `dogenode2.bbry.org`, `ethnode3.bbry.org`, and `ipfs6.bbry.org` proxy endpoints
+- Removed unavailable `ipfs1test.adamant.im` metadata after its TLS endpoint stopped serving
+
 ## [2.6.0] - 2026-06-27
 
 ### Added
@@ -112,15 +126,9 @@ All notable changes to this project will be documented in this file.
       "explorer": "http://xyz.onion",
       "explorerTx": "http://xyz.onion/tx/${ID}",
       "explorerAddress": "http://xyz.onion/address/${ID}",
-      "nodes": [
-        /*...*/
-      ],
-      "services": {
-        /*...*/
-      },
-      "links": [
-        /*...*/
-      ],
+      "nodes": [/*...*/],
+      "services": {/*...*/},
+      "links": [/*...*/],
     },
   }
   ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [Unreleased]
+## [2.7.0] - 2026-08-01
 
 ### Changed
 
@@ -14,7 +14,6 @@ All notable changes to this project will be documented in this file.
 ### Removed
 
 - Removed retired `btcnode1.bbry.org`, `dogenode2.bbry.org`, `ethnode3.bbry.org`, and `ipfs6.bbry.org` proxy endpoints
-- Removed unavailable `ipfs1test.adamant.im` metadata after its TLS endpoint stopped serving
 
 ## [2.6.0] - 2026-06-27
 

--- a/README.md
+++ b/README.md
@@ -140,9 +140,7 @@ Coin and token metadata is stored in `assets/general/${token_name}/info.json`. B
       },
       "minVersion": "1.0.0", // Optional. Minimal supported service API version
     },
-    "service2": {
-      /*...*/
-    },
+    "service2": {/*...*/},
   },
 
   // Optional. Additional project links
@@ -183,6 +181,8 @@ Do not duplicate general fields in token override files unless the blockchain-sp
 `nodes` describe blockchain API endpoints. `services` describe project-specific service groups such as info services, indexers, and IPFS nodes.
 
 Keep endpoint lists diverse. Do not replace a list with a single endpoint unless there is an explicit reliability reason. When editing endpoints that may be affected by DNS censorship or availability issues, keep valid `alt_ip` fallbacks where they already exist.
+
+`pnpm run validate:endpoints` checks every node and service list for absolute HTTP(S) URLs, literal-IP `alt_ip` fallbacks, and duplicate URLs. It is also included in the complete `pnpm run validate` command. Live availability still requires an explicit network check because CI validation is intentionally deterministic.
 
 Health checks use millisecond intervals:
 

--- a/assets/general/adamant/info.json
+++ b/assets/general/adamant/info.json
@@ -226,6 +226,9 @@
         },
         "list": [
           {
+            "url": "https://ipfs1test.adamant.im"
+          },
+          {
             "url": "https://ipfs2test.adamant.im"
           }
         ],

--- a/assets/general/adamant/info.json
+++ b/assets/general/adamant/info.json
@@ -131,10 +131,6 @@
         {
           "url": "https://ipfs4.bbry.org",
           "alt_ip": "http://65.108.52.254:61399"
-        },
-        {
-          "url": "https://ipfs6.bbry.org",
-          "alt_ip": "http://100.42.184.57:56777"
         }
       ],
       "healthCheck": {
@@ -229,9 +225,6 @@
           "docs": "https://github.com/Adamant-im/ipfs-node/blob/master/README.md"
         },
         "list": [
-          {
-            "url": "https://ipfs1test.adamant.im"
-          },
           {
             "url": "https://ipfs2test.adamant.im"
           }

--- a/assets/general/bitcoin/info.json
+++ b/assets/general/bitcoin/info.json
@@ -36,15 +36,11 @@
     "list": [
       {
         "url": "https://btcnode1.adamant.im/bitcoind",
-        "alt_ip": "http://176.9.38.204:44099/bitcoind"
+        "alt_ip": "http://75.119.138.235:44100/bitcoind"
       },
       {
         "url": "https://btcnode3.adamant.im/bitcoind",
         "alt_ip": "http://195.201.242.108:44099/bitcoind"
-      },
-      {
-        "url": "https://btcnode1.bbry.org/bitcoind",
-        "alt_ip": "http://100.42.184.57:8617/bitcoind"
       },
       {
         "url": "https://btcnode3.bbry.org/bitcoind",
@@ -69,15 +65,11 @@
       "list": [
         {
           "url": "https://btcnode1.adamant.im",
-          "alt_ip": "http://176.9.38.204:44099"
+          "alt_ip": "http://75.119.138.235:44100"
         },
         {
           "url": "https://btcnode3.adamant.im",
           "alt_ip": "http://195.201.242.108:44099"
-        },
-        {
-          "url": "https://btcnode1.bbry.org",
-          "alt_ip": "http://100.42.184.57:8617"
         },
         {
           "url": "https://btcnode3.bbry.org",

--- a/assets/general/doge/info.json
+++ b/assets/general/doge/info.json
@@ -35,7 +35,7 @@
     "list": [
       {
         "url": "https://dogenode2.adamant.im",
-        "alt_ip": "http://75.119.138.235:44098"
+        "alt_ip": "http://46.4.37.157:44098"
       },
       {
         "url": "https://dogenode3.adm.im",
@@ -64,15 +64,11 @@
       "list": [
         {
           "url": "https://dogenode2.adamant.im/api",
-          "alt_ip": "http://84.247.142.184:44098/api"
+          "alt_ip": "http://46.4.37.157:44098/api"
         },
         {
           "url": "https://dogenode3.adm.im/api",
           "alt_ip": "http://195.201.242.108:44098/api"
-        },
-        {
-          "url": "https://dogenode2.bbry.org/api",
-          "alt_ip": "http://51.15.238.199:7954/api"
         },
         {
           "url": "https://dogenode3.bbry.org/api",

--- a/assets/general/ethereum/info.json
+++ b/assets/general/ethereum/info.json
@@ -48,10 +48,6 @@
       {
         "url": "https://ethnode2.bbry.org",
         "alt_ip": "http://65.108.52.254:41311"
-      },
-      {
-        "url": "https://ethnode3.bbry.org",
-        "alt_ip": "http://100.42.184.57:7318"
       }
     ],
     "healthCheck": {
@@ -81,10 +77,6 @@
         {
           "url": "https://ethnode2.bbry.org",
           "alt_ip": "http://65.108.52.254:41311"
-        },
-        {
-          "url": "https://ethnode3.bbry.org",
-          "alt_ip": "http://100.42.184.57:7318"
         }
       ],
       "healthCheck": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "format": "prettier --write \"**/*.{json,md}\"",
     "format:check": "prettier --check \"**/*.{json,md}\"",
     "lint": "pnpm run format:check",
+    "test": "node --test scripts/*.test.mjs",
     "validate:json": "find assets specification -name '*.json' -print0 | xargs -0 -n 1 jq empty",
     "validate:endpoints": "node scripts/validate-endpoints.mjs",
     "validate": "pnpm run validate:json && pnpm run validate:endpoints && pnpm run format:check",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "2.7.0",
   "description": "Canonical wallet metadata and specifications for ADAMANT apps",
   "private": true,
-  "packageManager": "pnpm@10.11.0",
+  "packageManager": "pnpm@11.18.0",
   "engines": {
     "node": ">=22.22.1"
   },

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "format:check": "prettier --check \"**/*.{json,md}\"",
     "lint": "pnpm run format:check",
     "validate:json": "find assets specification -name '*.json' -print0 | xargs -0 -n 1 jq empty",
-    "validate": "pnpm run validate:json && pnpm run format:check",
+    "validate:endpoints": "node scripts/validate-endpoints.mjs",
+    "validate": "pnpm run validate:json && pnpm run validate:endpoints && pnpm run format:check",
     "prepare": "husky"
   },
   "keywords": [
@@ -42,8 +43,8 @@
   "devDependencies": {
     "@prettier/plugin-xml": "^3.4.2",
     "husky": "^9.1.7",
-    "lint-staged": "^17.0.8",
-    "prettier": "^3.8.5"
+    "lint-staged": "^17.3.0",
+    "prettier": "^3.9.6"
   },
   "lint-staged": {
     "*.{json,svg,vue}": "prettier --write"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adamant-wallets",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "description": "Canonical wallet metadata and specifications for ADAMANT apps",
   "private": true,
   "packageManager": "pnpm@10.11.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,16 +10,16 @@ importers:
     devDependencies:
       '@prettier/plugin-xml':
         specifier: ^3.4.2
-        version: 3.4.2(prettier@3.8.5)
+        version: 3.4.2(prettier@3.9.6)
       husky:
         specifier: ^9.1.7
         version: 9.1.7
       lint-staged:
-        specifier: ^17.0.8
-        version: 17.0.8
+        specifier: ^17.3.0
+        version: 17.3.0
       prettier:
-        specifier: ^3.8.5
-        version: 3.8.5
+        specifier: ^3.9.6
+        version: 3.9.6
 
 packages:
 
@@ -31,130 +31,37 @@ packages:
   '@xml-tools/parser@1.0.11':
     resolution: {integrity: sha512-aKqQ077XnR+oQtHJlrAflaZaL7qZsulWc/i/ZEooar5JiWj1eLt0+Wg28cpa+XLney107wXqneC+oG1IZvxkTA==}
 
-  ansi-escapes@7.3.0:
-    resolution: {integrity: sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==}
-    engines: {node: '>=18'}
-
-  ansi-regex@6.2.2:
-    resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
-    engines: {node: '>=12'}
-
-  ansi-styles@6.2.3:
-    resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
-    engines: {node: '>=12'}
-
   chevrotain@7.1.1:
     resolution: {integrity: sha512-wy3mC1x4ye+O+QkEinVJkPf5u2vsrDIYW9G7ZuwFl6v/Yu0LwUuT2POsb+NUWApebyxfkQq6+yDfRExbnI5rcw==}
-
-  cli-cursor@5.0.0:
-    resolution: {integrity: sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==}
-    engines: {node: '>=18'}
-
-  cli-truncate@5.2.0:
-    resolution: {integrity: sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==}
-    engines: {node: '>=20'}
-
-  emoji-regex@10.6.0:
-    resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
-
-  environment@1.1.0:
-    resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
-    engines: {node: '>=18'}
-
-  eventemitter3@5.0.4:
-    resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
-
-  get-east-asian-width@1.6.0:
-    resolution: {integrity: sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==}
-    engines: {node: '>=18'}
 
   husky@9.1.7:
     resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
     engines: {node: '>=18'}
     hasBin: true
 
-  is-fullwidth-code-point@5.1.0:
-    resolution: {integrity: sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==}
-    engines: {node: '>=18'}
-
-  lint-staged@17.0.8:
-    resolution: {integrity: sha512-B2P/d+jVW0UXOQ0MVMLrB/9ydA1P+zz6jYfdrbbEd9ur3S2rcbduFWKiUCC02Sm5hbC8nrm7y24WuYMG54HfxA==}
+  lint-staged@17.3.0:
+    resolution: {integrity: sha512-woZS3vNe3UKqBaLPvbLOtKRY4tLANpWQhom12MGWqC8Mh1lCOO+WgSwmX2amjJAqTY9BkXYW87fCUH5H9Ph6xw==}
     engines: {node: '>=22.22.1'}
     hasBin: true
 
-  listr2@10.2.2:
-    resolution: {integrity: sha512-JtNtbZj8q5BnDMR7trpwvwk3RIrANtIVzEUm8w7amp6xelLgyuq+4WZoTH913XaQAoH/cNdYhaNzBPA2U3xbDw==}
-    engines: {node: '>=22.13.0'}
-
-  log-update@6.1.0:
-    resolution: {integrity: sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==}
-    engines: {node: '>=18'}
-
-  mimic-function@5.0.1:
-    resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
-    engines: {node: '>=18'}
-
-  onetime@7.0.0:
-    resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
-    engines: {node: '>=18'}
-
-  picomatch@4.0.4:
-    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+  picomatch@4.0.5:
+    resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
     engines: {node: '>=12'}
 
-  prettier@3.8.5:
-    resolution: {integrity: sha512-zxcTTCedNGJM4R8sj/Cq/F0W/c4iE0afWBcBwMTRtw4WHYP9TWkYjdiH3npPRUYsXQCPR0hTU9yjovOu+E6EQA==}
+  prettier@3.9.6:
+    resolution: {integrity: sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==}
     engines: {node: '>=14'}
     hasBin: true
 
   regexp-to-ast@0.5.0:
     resolution: {integrity: sha512-tlbJqcMHnPKI9zSrystikWKwHkBqu2a/Sgw01h3zFjvYrMxEDYHzzoMZnUrbIfpTFEsoRnnviOXNCzFiSc54Qw==}
 
-  restore-cursor@5.1.0:
-    resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
-    engines: {node: '>=18'}
-
-  rfdc@1.4.1:
-    resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
-
-  signal-exit@4.1.0:
-    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
-    engines: {node: '>=14'}
-
-  slice-ansi@7.1.2:
-    resolution: {integrity: sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==}
-    engines: {node: '>=18'}
-
-  slice-ansi@8.0.0:
-    resolution: {integrity: sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==}
-    engines: {node: '>=20'}
-
   string-argv@0.3.2:
     resolution: {integrity: sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==}
     engines: {node: '>=0.6.19'}
 
-  string-width@7.2.0:
-    resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
-    engines: {node: '>=18'}
-
-  string-width@8.2.1:
-    resolution: {integrity: sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==}
-    engines: {node: '>=20'}
-
-  strip-ansi@7.2.0:
-    resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
-    engines: {node: '>=12'}
-
   tinyexec@1.2.4:
     resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
-    engines: {node: '>=18'}
-
-  wrap-ansi@10.0.0:
-    resolution: {integrity: sha512-SGcvg80f0wUy2/fXES19feHMz8E0JoXv2uNgHOu4Dgi2OrCy1lqwFYEJz1BLbDI0exjPMe/ZdzZ/YpGECBG/aQ==}
-    engines: {node: '>=20'}
-
-  wrap-ansi@9.0.2:
-    resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
     engines: {node: '>=18'}
 
   yaml@2.9.0:
@@ -164,136 +71,38 @@ packages:
 
 snapshots:
 
-  '@prettier/plugin-xml@3.4.2(prettier@3.8.5)':
+  '@prettier/plugin-xml@3.4.2(prettier@3.9.6)':
     dependencies:
       '@xml-tools/parser': 1.0.11
-      prettier: 3.8.5
+      prettier: 3.9.6
 
   '@xml-tools/parser@1.0.11':
     dependencies:
       chevrotain: 7.1.1
 
-  ansi-escapes@7.3.0:
-    dependencies:
-      environment: 1.1.0
-
-  ansi-regex@6.2.2: {}
-
-  ansi-styles@6.2.3: {}
-
   chevrotain@7.1.1:
     dependencies:
       regexp-to-ast: 0.5.0
 
-  cli-cursor@5.0.0:
-    dependencies:
-      restore-cursor: 5.1.0
-
-  cli-truncate@5.2.0:
-    dependencies:
-      slice-ansi: 8.0.0
-      string-width: 8.2.1
-
-  emoji-regex@10.6.0: {}
-
-  environment@1.1.0: {}
-
-  eventemitter3@5.0.4: {}
-
-  get-east-asian-width@1.6.0: {}
-
   husky@9.1.7: {}
 
-  is-fullwidth-code-point@5.1.0:
+  lint-staged@17.3.0:
     dependencies:
-      get-east-asian-width: 1.6.0
-
-  lint-staged@17.0.8:
-    dependencies:
-      listr2: 10.2.2
-      picomatch: 4.0.4
+      picomatch: 4.0.5
       string-argv: 0.3.2
       tinyexec: 1.2.4
     optionalDependencies:
       yaml: 2.9.0
 
-  listr2@10.2.2:
-    dependencies:
-      cli-truncate: 5.2.0
-      eventemitter3: 5.0.4
-      log-update: 6.1.0
-      rfdc: 1.4.1
-      wrap-ansi: 10.0.0
+  picomatch@4.0.5: {}
 
-  log-update@6.1.0:
-    dependencies:
-      ansi-escapes: 7.3.0
-      cli-cursor: 5.0.0
-      slice-ansi: 7.1.2
-      strip-ansi: 7.2.0
-      wrap-ansi: 9.0.2
-
-  mimic-function@5.0.1: {}
-
-  onetime@7.0.0:
-    dependencies:
-      mimic-function: 5.0.1
-
-  picomatch@4.0.4: {}
-
-  prettier@3.8.5: {}
+  prettier@3.9.6: {}
 
   regexp-to-ast@0.5.0: {}
 
-  restore-cursor@5.1.0:
-    dependencies:
-      onetime: 7.0.0
-      signal-exit: 4.1.0
-
-  rfdc@1.4.1: {}
-
-  signal-exit@4.1.0: {}
-
-  slice-ansi@7.1.2:
-    dependencies:
-      ansi-styles: 6.2.3
-      is-fullwidth-code-point: 5.1.0
-
-  slice-ansi@8.0.0:
-    dependencies:
-      ansi-styles: 6.2.3
-      is-fullwidth-code-point: 5.1.0
-
   string-argv@0.3.2: {}
 
-  string-width@7.2.0:
-    dependencies:
-      emoji-regex: 10.6.0
-      get-east-asian-width: 1.6.0
-      strip-ansi: 7.2.0
-
-  string-width@8.2.1:
-    dependencies:
-      get-east-asian-width: 1.6.0
-      strip-ansi: 7.2.0
-
-  strip-ansi@7.2.0:
-    dependencies:
-      ansi-regex: 6.2.2
-
   tinyexec@1.2.4: {}
-
-  wrap-ansi@10.0.0:
-    dependencies:
-      ansi-styles: 6.2.3
-      string-width: 8.2.1
-      strip-ansi: 7.2.0
-
-  wrap-ansi@9.0.2:
-    dependencies:
-      ansi-styles: 6.2.3
-      string-width: 7.2.0
-      strip-ansi: 7.2.0
 
   yaml@2.9.0:
     optional: true

--- a/scripts/validate-endpoints.mjs
+++ b/scripts/validate-endpoints.mjs
@@ -1,0 +1,96 @@
+import { isIP } from "node:net";
+import { readdirSync, readFileSync } from "node:fs";
+import { join, relative } from "node:path";
+
+const errors = [];
+
+function jsonFiles(directory) {
+  return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const entryPath = join(directory, entry.name);
+
+    if (entry.isDirectory()) {
+      return jsonFiles(entryPath);
+    }
+
+    return entry.isFile() && entry.name.endsWith(".json") ? [entryPath] : [];
+  });
+}
+
+function validateUrl(value, location, requireIp = false) {
+  let parsed;
+
+  try {
+    parsed = new URL(value);
+  } catch {
+    errors.push(
+      `${location}: expected an absolute URL, got ${JSON.stringify(value)}`,
+    );
+    return;
+  }
+
+  if (!["http:", "https:"].includes(parsed.protocol)) {
+    errors.push(`${location}: expected an HTTP(S) URL, got ${parsed.protocol}`);
+  }
+
+  if (requireIp && !isIP(parsed.hostname)) {
+    errors.push(`${location}: alt_ip hostname must be a literal IP address`);
+  }
+}
+
+function walk(value, location) {
+  if (!value || typeof value !== "object") {
+    return;
+  }
+
+  if (
+    Array.isArray(value.list) &&
+    value.list.every(
+      (item) => item && typeof item === "object" && "url" in item,
+    )
+  ) {
+    const seenUrls = new Set();
+
+    value.list.forEach((endpoint, index) => {
+      const endpointLocation = `${location}.list[${index}]`;
+
+      if (typeof endpoint.url !== "string" || !endpoint.url) {
+        errors.push(`${endpointLocation}.url: expected a non-empty string`);
+      } else {
+        validateUrl(endpoint.url, `${endpointLocation}.url`);
+
+        if (seenUrls.has(endpoint.url)) {
+          errors.push(
+            `${endpointLocation}.url: duplicate endpoint ${endpoint.url}`,
+          );
+        }
+
+        seenUrls.add(endpoint.url);
+      }
+
+      if ("alt_ip" in endpoint) {
+        if (typeof endpoint.alt_ip !== "string" || !endpoint.alt_ip) {
+          errors.push(
+            `${endpointLocation}.alt_ip: expected a non-empty string`,
+          );
+        } else {
+          validateUrl(endpoint.alt_ip, `${endpointLocation}.alt_ip`, true);
+        }
+      }
+    });
+  }
+
+  for (const [key, child] of Object.entries(value)) {
+    walk(child, `${location}.${key}`);
+  }
+}
+
+for (const file of jsonFiles("assets")) {
+  walk(JSON.parse(readFileSync(file, "utf8")), relative(".", file));
+}
+
+if (errors.length) {
+  console.error(errors.join("\n"));
+  process.exitCode = 1;
+} else {
+  console.log("All node and service endpoint lists are structurally valid");
+}

--- a/scripts/validate-endpoints.mjs
+++ b/scripts/validate-endpoints.mjs
@@ -5,15 +5,19 @@ import { join, relative } from "node:path";
 const errors = [];
 
 function jsonFiles(directory) {
-  return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
-    const entryPath = join(directory, entry.name);
+  return readdirSync(directory, { withFileTypes: true })
+    .sort((left, right) =>
+      left.name < right.name ? -1 : left.name > right.name ? 1 : 0,
+    )
+    .flatMap((entry) => {
+      const entryPath = join(directory, entry.name);
 
-    if (entry.isDirectory()) {
-      return jsonFiles(entryPath);
-    }
+      if (entry.isDirectory()) {
+        return jsonFiles(entryPath);
+      }
 
-    return entry.isFile() && entry.name.endsWith(".json") ? [entryPath] : [];
-  });
+      return entry.isFile() && entry.name.endsWith(".json") ? [entryPath] : [];
+    });
 }
 
 function validateUrl(value, location, requireIp = false) {
@@ -44,14 +48,27 @@ function walk(value, location) {
 
   if (
     Array.isArray(value.list) &&
-    value.list.every(
-      (item) => item && typeof item === "object" && "url" in item,
+    value.list.some(
+      (item) =>
+        item &&
+        typeof item === "object" &&
+        !Array.isArray(item) &&
+        "url" in item,
     )
   ) {
     const seenUrls = new Set();
 
     value.list.forEach((endpoint, index) => {
       const endpointLocation = `${location}.list[${index}]`;
+
+      if (
+        !endpoint ||
+        typeof endpoint !== "object" ||
+        Array.isArray(endpoint)
+      ) {
+        errors.push(`${endpointLocation}: expected an endpoint object`);
+        return;
+      }
 
       if (typeof endpoint.url !== "string" || !endpoint.url) {
         errors.push(`${endpointLocation}.url: expected a non-empty string`);

--- a/scripts/validate-endpoints.test.mjs
+++ b/scripts/validate-endpoints.test.mjs
@@ -1,0 +1,63 @@
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+const validator = fileURLToPath(
+  new URL("./validate-endpoints.mjs", import.meta.url),
+);
+
+function runValidator(files) {
+  const directory = mkdtempSync(join(tmpdir(), "wallet-endpoints-"));
+
+  try {
+    for (const [path, contents] of Object.entries(files)) {
+      const destination = join(directory, "assets", path);
+      mkdirSync(dirname(destination), { recursive: true });
+      writeFileSync(destination, JSON.stringify(contents));
+    }
+
+    return spawnSync(process.execPath, [validator], {
+      cwd: directory,
+      encoding: "utf8",
+    });
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+}
+
+test("reports validation errors in deterministic file order", () => {
+  const result = runValidator({
+    "z/info.json": { nodes: { list: [{ url: "invalid-z" }] } },
+    "a/info.json": { nodes: { list: [{ url: "invalid-a" }] } },
+  });
+
+  assert.equal(result.status, 1);
+  assert.deepEqual(result.stderr.trim().split("\n"), [
+    'assets/a/info.json.nodes.list[0].url: expected an absolute URL, got "invalid-a"',
+    'assets/z/info.json.nodes.list[0].url: expected an absolute URL, got "invalid-z"',
+  ]);
+});
+
+test("reports malformed entries in an endpoint list", () => {
+  const result = runValidator({
+    "coin/info.json": {
+      nodes: {
+        list: [
+          { alt_ip: "http://127.0.0.1" },
+          null,
+          { url: "https://node.example" },
+        ],
+      },
+    },
+  });
+
+  assert.equal(result.status, 1);
+  assert.deepEqual(result.stderr.trim().split("\n"), [
+    "assets/coin/info.json.nodes.list[0].url: expected a non-empty string",
+    "assets/coin/info.json.nodes.list[1]: expected an endpoint object",
+  ]);
+});


### PR DESCRIPTION
## Description

- replace the migrated `btcnode1` and `dogenode2` IP fallbacks with `75.119.138.235:44100` and `46.4.37.157:44098`
- remove the retired `btcnode1.bbry.org`, `dogenode2.bbry.org`, `ethnode3.bbry.org`, and `ipfs6.bbry.org` proxy endpoints
- add deterministic validation for absolute endpoint URLs, literal-IP fallbacks, and duplicates inside node/service groups
- update Prettier from 3.8.5 to 3.9.6 and lint-staged from 17.0.8 to 17.3.0; the new lint-staged dependency graph removes 28 transitive packages
- update the pinned package manager from pnpm 10.11.0 to 11.18.0
- prepare the metadata package as version 2.7.0 and document the new validation command and release changes

## Related issue

Closes #139

## External links (optional)

None.

## Screenshots or videos (optional)

Not applicable.

## Breaking changes

No metadata shape changes. Wallets that still select the retired proxy endpoints will instead use the remaining direct and bbry providers after consuming this metadata update.

## How to test

1. Run `pnpm install --ignore-scripts --frozen-lockfile`
2. Run `pnpm run validate`
3. Run `pnpm audit`
4. Confirm that the retired domains/IPs no longer appear outside the changelog
5. Confirm that DNS A records match every configured `alt_ip`
6. Probe the BTC, DOGE, ETH, and IPFS domain/IP endpoints with their native APIs
7. Probe the BTC and DOGE Onion endpoints through Tor

Validation completed locally with Node.js 26.5.0 and pnpm 11.18.0:

- JSON, endpoint, and formatting validation passed
- `pnpm audit` reported no known vulnerabilities
- all configured clearnet node/service URLs passed a strict connectivity check except `btcnode1.adamant.im`, which is intentionally disabled until its new Electrs indexer reaches the Bitcoin tip
- BTC RPC is synchronized and reachable by IP and Tor; the BTC indexer is still completing its initial sync
- DOGE RPC/indexer, ETH JSON-RPC, and IPFS endpoints passed domain/IP checks; migrated DOGE Onion RPC/indexer checks also passed
- DOGE domain/IP/Onion indexer responses expose a single valid CORS origin header after the live proxy fix
- `ipfs1test.adamant.im` was restored, upgraded, reboot-tested, and retained in the canonical IPFS endpoint list
- README, OpenAPI, AGENTS, and contribution guidance were reviewed; OpenAPI and AGENTS need no change because the metadata shape and contributor rules are unchanged

## Notes for reviewers

The PR is intentionally a draft until `btcnode1` Electrs reaches the Bitcoin tip and the domain endpoint is re-enabled and verified. The endpoint validator is deterministic and does not perform network requests in CI.

Dependency installation and lockfile updates were performed with lifecycle scripts disabled. Registry metadata, maintainers, repositories, package contents, changed transitive dependencies, licenses, and suspicious execution/network patterns were reviewed before the update. The updated published packages do not require install-time scripts.

## Checklist

- [x] Code is formatted
- [x] Tests added/updated (if needed)
- [x] Documentation updated (if needed)
- [ ] Changes tested in all relevant environments (pending BTC Electrs completion)
